### PR TITLE
68 zeltplatz tent details page zelt bearbeiten

### DIFF
--- a/backend/src/main/java/com/example/backend/controller/TentController.java
+++ b/backend/src/main/java/com/example/backend/controller/TentController.java
@@ -31,4 +31,9 @@ public class TentController {
     public TentItem addTentItem (@RequestBody TentItemDTO newTentItem) {
         return tentItemService.addTentItem(newTentItem);
     }
+
+    @PutMapping("{id}")
+    public TentItem updateTentItem (@PathVariable String id, @RequestBody TentItemDTO changedTentItem) {
+        return tentItemService.updateTentItem(id, changedTentItem);
+    }
 }

--- a/backend/src/main/java/com/example/backend/controller/TentController.java
+++ b/backend/src/main/java/com/example/backend/controller/TentController.java
@@ -18,22 +18,22 @@ public class TentController {
     }
 
     @GetMapping
-    public List<TentItem> getTentItems () {
+    public List<TentItem> getTentItems() {
         return tentItemService.getTentItems();
     }
 
     @GetMapping("{id}")
-    public TentItem getTentItemByID (@PathVariable String id) {
+    public TentItem getTentItemByID(@PathVariable String id) {
         return tentItemService.getTentItemByID(id);
     }
 
     @PostMapping
-    public TentItem addTentItem (@RequestBody TentItemDTO newTentItem) {
+    public TentItem addTentItem(@RequestBody TentItemDTO newTentItem) {
         return tentItemService.addTentItem(newTentItem);
     }
 
     @PutMapping("{id}")
-    public TentItem updateTentItem (@PathVariable String id, @RequestBody TentItemDTO changedTentItem) {
+    public TentItem updateTentItem(@PathVariable String id, @RequestBody TentItemDTO changedTentItem) {
         return tentItemService.updateTentItem(id, changedTentItem);
     }
 }

--- a/backend/src/main/java/com/example/backend/service/TentItemService.java
+++ b/backend/src/main/java/com/example/backend/service/TentItemService.java
@@ -20,15 +20,15 @@ public class TentItemService {
         this.tentItemRepository = tentItemRepository;
     }
 
-    public List<TentItem> getTentItems () {
+    public List<TentItem> getTentItems() {
         return tentItemRepository.findAll();
     }
 
-    public TentItem getTentItemByID (String id) {
+    public TentItem getTentItemByID(String id) {
         return tentItemRepository.findById(id).orElseThrow(() -> new NoSuchElementException("Item not found"));
     }
 
-    public TentItem addTentItem (TentItemDTO newTentItem) {
+    public TentItem addTentItem(TentItemDTO newTentItem) {
         return tentItemRepository.insert(TentItem.builder()
                 .title(newTentItem.getTitle())
                 .description(newTentItem.getDescription())
@@ -37,6 +37,19 @@ public class TentItemService {
                 .spending(newTentItem.getSpending())
                 .capacity(newTentItem.getCapacity())
                 .shelter(newTentItem.isShelter())
+                .build());
+    }
+
+    public TentItem updateTentItem(String id, TentItemDTO changedTentItem) {
+        return tentItemRepository.save(TentItem.builder()
+                .id(id)
+                .title(changedTentItem.getTitle())
+                .description(changedTentItem.getDescription())
+                .owner(changedTentItem.getOwner())
+                .involved(changedTentItem.getInvolved())
+                .spending(changedTentItem.getSpending())
+                .capacity(changedTentItem.getCapacity())
+                .shelter(changedTentItem.isShelter())
                 .build());
     }
 

--- a/backend/src/test/java/com/example/backend/controller/TentControllerTest.java
+++ b/backend/src/test/java/com/example/backend/controller/TentControllerTest.java
@@ -187,4 +187,56 @@ class TentControllerTest {
         TentItem expected = testTent;
         assertEquals(expected, actual);
     }
+
+    @Test
+    void updateTentItem() {
+        //given
+        TentItem testTent = TentItem.builder()
+                .id("1")
+                .title("Zelt")
+                .description("groß")
+                .owner("owner1")
+                .involved(new ArrayList<>(Arrays.asList("involved1", "involved2")))
+                .spending("")
+                .capacity(3)
+                .shelter(false)
+                .build();
+
+        TentItemDTO testTentDTO = TentItemDTO.builder()
+                .title("Zelt")
+                .description("groß")
+                .owner("owner1")
+                .involved(new ArrayList<>(Arrays.asList("involved1", "involved2")))
+                .spending("")
+                .capacity(3)
+                .shelter(false)
+                .build();
+
+        tentItemRepository.insert(testTent);
+
+        //when
+        TentItem actualItem = webTestClient.put()
+                .uri("http://localhost:" + port + "/project/tents/" + testTent.getId())
+                .headers(http -> http.setBearerAuth(jwtToken))
+                .bodyValue(testTentDTO)
+                .exchange()
+                .expectBody(TentItem.class)
+                .returnResult()
+                .getResponseBody();
+
+        List<TentItem> actualList = webTestClient.get()
+                .uri("http://localhost:" + port + "/project/tents")
+                .headers(http -> http.setBearerAuth(jwtToken))
+                .exchange()
+                .expectBodyList(TentItem.class)
+                .returnResult()
+                .getResponseBody();
+
+        //then
+        TentItem expectedItem = testTent;
+        List<TentItem> expectedList = List.of(testTent);
+
+        assertEquals(expectedItem, actualItem);
+        assertEquals(expectedList, actualList);
+    }
 }

--- a/backend/src/test/java/com/example/backend/service/TentItemServiceTest.java
+++ b/backend/src/test/java/com/example/backend/service/TentItemServiceTest.java
@@ -119,4 +119,39 @@ class TentItemServiceTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void updateTentItem() {
+        //given
+        TentItem testTent1 = TentItem.builder()
+                .id("1")
+                .title("Iglu")
+                .description("klein")
+                .owner("owner1")
+                .involved(new ArrayList<>(Arrays.asList("involved1", "involved2")))
+                .spending("")
+                .capacity(3)
+                .shelter(false)
+                .build();
+
+
+        TentItemDTO testTentDTO1 = TentItemDTO.builder()
+                .title("Iglu")
+                .description("klein")
+                .owner("owner1")
+                .involved(new ArrayList<>(Arrays.asList("involved1", "involved2")))
+                .spending("")
+                .capacity(3)
+                .shelter(false)
+                .build();
+
+        when(tentItemRepository.save(testTent1)).thenReturn(testTent1);
+
+        //when
+        TentItem actual = tentItemService.updateTentItem("1", testTentDTO1);
+
+        //then
+        TentItem expected = testTent1;
+        verify(tentItemRepository).save(testTent1);
+        assertEquals(expected, actual);
+    }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -23,7 +23,7 @@ function App() {
     const currentUser = useAppUser()
     const appUsers = useAllAppUsers()
     const {carItems, addCarItem, updateCarItem, removeCarItem} = useCarItems()
-    const {tentItems, addTentItem} = useTentItems()
+    const {tentItems, addTentItem, updateTentItem} = useTentItems()
 
     return (
     <div className="App">

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -37,7 +37,7 @@ function App() {
                 <Route path={"/campsite/addcar"} element={<AddCarItemPage addCarItem={addCarItem} currentUser={currentUser}/>}/>
                 <Route path={"/campsite/addtent"} element={<AddTentItemPage  addTentItem={addTentItem} currentUser={currentUser}/>}/>
                 <Route path={`/campsite/car/:id`} element={<CarDetailsPage appUsers={appUsers} currentUser={currentUser} updateCarItem={updateCarItem} removeCarItem={removeCarItem}/>}/>
-                <Route path={`/campsite/tent/:id`} element={<TentDetailsPage appUsers={appUsers} currentUser={currentUser}/>} />
+                <Route path={`/campsite/tent/:id`} element={<TentDetailsPage appUsers={appUsers} currentUser={currentUser} updateTentItem={updateTentItem}/>} />
             </Route>
             <Route path={'/login'} element={<LoginPage />}/>
         </Routes>

--- a/frontend/src/components/EquipmentItemCardView.tsx
+++ b/frontend/src/components/EquipmentItemCardView.tsx
@@ -16,6 +16,8 @@ export default function EquipmentItemCardView({equipmentItems, appUsers}: Equipm
     }
 
     return <div className={"container"}>
-        {equipmentItems.length > 0  ? (equipmentItems.map(item => <EquipmentItemCard key={item.id} equipmentItem={item}  ownerName={getOwnerName(item)}/>)): <p>Nichts da</p>}
+        {equipmentItems.filter(item => !item.important).length > 0 ?
+            equipmentItems.filter(item => !item.important)
+                .map(item => <EquipmentItemCard key={item.id} equipmentItem={item}  ownerName={getOwnerName(item)}/>): <p>Nichts da</p>}
     </div>
 }

--- a/frontend/src/components/EquipmentItemImportantCardView.tsx
+++ b/frontend/src/components/EquipmentItemImportantCardView.tsx
@@ -18,9 +18,9 @@ export type EquipmentItemImportantCardViewProps = {
 
         return <div className={"important_container"}>
             <Button variant="outline-danger">Wichtig</Button>
-            <div className={"card_container"}>{equipmentItems.filter(item => item.important).length > 0 &&
+            <div className={"card_container"}>{equipmentItems.filter(item => item.important).length > 0 ?
                 equipmentItems.filter(item => item.important)
-                    .map(item => <EquipmentItemCard key={item.id} equipmentItem={item}  ownerName={getOwnerName(item)}/>)}
+                    .map(item => <EquipmentItemCard key={item.id} equipmentItem={item}  ownerName={getOwnerName(item)}/>): <p>Keine wichtigen Items</p>}
             </div>
         </div>
 

--- a/frontend/src/hooks/useTentItems.ts
+++ b/frontend/src/hooks/useTentItems.ts
@@ -1,7 +1,7 @@
 import {useContext, useEffect, useState} from "react";
 import {TentItem} from "../model/TentItem";
 import {AuthContext} from "../context/AuthProvider";
-import {getAllTentItems, postTentItem} from "../service/TentItemApiService";
+import {getAllTentItems, postTentItem, putTentItem} from "../service/TentItemApiService";
 import {Omit} from "react-bootstrap/helpers";
 
 
@@ -21,5 +21,11 @@ export default function useTentItems() {
             .catch(console.error)
     }
 
-    return {tentItems, addTentItem}
+    const updateTentItem = (changedTentItem: TentItem) => {
+        putTentItem(changedTentItem)
+            .then(response => setTentItems(tentItems.map(tent => tent.id === response.id? response : tent)))
+            .catch(console.error)
+    }
+
+    return {tentItems, addTentItem, updateTentItem}
 }

--- a/frontend/src/pages/TentDetailsPage.tsx
+++ b/frontend/src/pages/TentDetailsPage.tsx
@@ -7,17 +7,19 @@ import DetailsPageOwnerField from "../components/DetailsPageOwnerField";
 import DetailsPageInvolvedField from "../components/DetailsPageInvolvedField";
 import {Button, Stack} from "react-bootstrap";
 import "./TentDetailsPage.css"
+import {TentItem} from "../model/TentItem";
 
 
 type TentDetailsPageProps = {
     appUsers: AppUser[]
     currentUser: AppUser
+    updateTentItem: (changedTentItem: TentItem) => void
 }
 
-export default function TentDetailsPage({appUsers, currentUser}: TentDetailsPageProps) {
+export default function TentDetailsPage({appUsers, currentUser, updateTentItem}: TentDetailsPageProps) {
     const {tentItem, getSingleTentItemByID} = useSingleTentItem()
     const {id} = useParams()
-
+    const [tentID, setTentID] = useState<string>("")
     const [title, setTitle] = useState<string>("")
     const [description, setDescription] = useState<string>("")
     const [owner, setOwner] = useState<string>("")
@@ -37,6 +39,7 @@ export default function TentDetailsPage({appUsers, currentUser}: TentDetailsPage
 
     useEffect(() => {
         if (tentItem) {
+            setTentID(tentItem.id)
             setTitle(tentItem.title)
             setDescription(tentItem.description)
             setOwner(tentItem.owner)
@@ -55,6 +58,20 @@ export default function TentDetailsPage({appUsers, currentUser}: TentDetailsPage
             }
         }
         return "Keiner"
+    }
+
+    const onSave = () => {
+        const changedTentItem = {
+            id: tentID,
+            title: title,
+            description: description,
+            owner: owner,
+            involved: involved,
+            capacity: capacity,
+            shelter: shelter
+        }
+        updateTentItem(changedTentItem)
+        navigate("/campsite")
     }
 
 
@@ -88,7 +105,7 @@ export default function TentDetailsPage({appUsers, currentUser}: TentDetailsPage
                                     onClick={() => setEditMode(!editMode)}>Bearbeiten</Button>}
                         {editMode? <Button type={"button"}
                                            onClick={() => setEditMode(!editMode)}>Speichern</Button> :
-                            <Button type={"submit"} onClick={() => navigate("/campsite")}>Fertig</Button>}
+                            <Button type={"submit"} onClick={() => onSave()}>Fertig</Button>}
                     </div>
                 </Stack>
             </div>

--- a/frontend/src/service/TentItemApiService.ts
+++ b/frontend/src/service/TentItemApiService.ts
@@ -19,3 +19,9 @@ export const getSingleTentItem: (tentID: string, token?: string) => Promise<Tent
         ? {headers: {"Authorization": token}}: {})
         .then(response => response.data)
 }
+
+export const putTentItem: (changedTentItem: TentItem, token?: string) => Promise<TentItem> = (changedTentItem, token ) => {
+    return axios.put("/project/tents/" + changedTentItem.id, token
+        ? {headers: {"Authorization": token}}: {})
+        .then(response => response.data)
+}


### PR DESCRIPTION
Item bearbeiten inkl. ein-/austragen.
- Klick auf Bearbeiten aktiviert den Editmode und die Textfelder
- Klick auf eintragen trägt den User ein, bei austragen wird der user ausgetragen
- klick auf Fertig speichert alle Änderungen und führt auf die Campsite Page zurück

Bugfix: "Wcihtige" Equipmentitems werden nicht mehr doppelt angezeigt (sondern nur noch im "Wichtig" Bereich)